### PR TITLE
parallel is now a module only, and no longer a class.

### DIFF
--- a/modred/__init__.py
+++ b/modred/__init__.py
@@ -47,7 +47,7 @@ from .vectors import (
     InnerProductTrapz, inner_product_array_uniform
 )
 
-from .parallel import Parallel, ParallelError, parallel_default_instance
+from . import parallel
 
 from .util import (
     UndefinedError, make_mat, make_iterable, flatten_list, save_array_text,

--- a/modred/bpod.py
+++ b/modred/bpod.py
@@ -5,8 +5,7 @@ import numpy as np
 
 from .vectorspace import VectorSpaceMatrices, VectorSpaceHandles
 from . import util
-from .parallel import parallel_default_instance
-_parallel = parallel_default_instance
+from . import parallel
 
 
 def compute_BPOD_matrices(
@@ -58,7 +57,7 @@ def compute_BPOD_matrices(
 
     See also :py:class:`BPODHandles`.
     """
-    if _parallel.is_distributed():
+    if parallel.is_distributed():
         raise RuntimeError('Cannot run in parallel.')
     vec_space = VectorSpaceMatrices(weights=inner_product_weights)
     direct_vecs = util.make_mat(direct_vecs)
@@ -155,11 +154,11 @@ class BPODHandles(object):
             ``R_sing_vecs_src``: Source from which to retrieve right singular
             vectors of Hankel matrix.
         """
-        self.sing_vals = np.squeeze(_parallel.call_and_bcast(
+        self.sing_vals = np.squeeze(parallel.call_and_bcast(
             self.get_mat, sing_vals_src))
-        self.L_sing_vecs = _parallel.call_and_bcast(
+        self.L_sing_vecs = parallel.call_and_bcast(
             self.get_mat, L_sing_vecs_src)
-        self.R_sing_vecs = _parallel.call_and_bcast(
+        self.R_sing_vecs = parallel.call_and_bcast(
             self.get_mat, R_sing_vecs_src)
 
 
@@ -184,44 +183,44 @@ class BPODHandles(object):
 
     def put_L_sing_vecs(self, dest):
         """Puts left singular vectors of Hankel matrix to ``dest``."""
-        if _parallel.is_rank_zero():
+        if parallel.is_rank_zero():
             self.put_mat(self.L_sing_vecs, dest)
-        _parallel.barrier()
+        parallel.barrier()
 
 
     def put_sing_vals(self, dest):
         """Puts Hankel singular values to ``dest``."""
-        if _parallel.is_rank_zero():
+        if parallel.is_rank_zero():
             self.put_mat(self.sing_vals, dest)
-        _parallel.barrier()
+        parallel.barrier()
 
 
     def put_R_sing_vecs(self, dest):
         """Puts right singular vectors of Hankel matrix to ``dest``."""
-        if _parallel.is_rank_zero():
+        if parallel.is_rank_zero():
             self.put_mat(self.R_sing_vecs, dest)
-        _parallel.barrier()
+        parallel.barrier()
 
 
     def put_Hankel_mat(self, dest):
         """Puts Hankel matrix to ``dest``."""
-        if _parallel.is_rank_zero():
+        if parallel.is_rank_zero():
             self.put_mat(self.Hankel_mat, dest)
-        _parallel.barrier()
+        parallel.barrier()
 
 
     def put_direct_proj_coeffs(self, dest):
         """Puts direct projection coefficients to ``dest``"""
-        if _parallel.is_rank_zero():
+        if parallel.is_rank_zero():
             self.put_mat(self.proj_coeffs, dest)
-        _parallel.barrier()
+        parallel.barrier()
 
 
     def put_adjoint_proj_coeffs(self, dest):
         """Puts adjoint projection coefficients to ``dest``"""
-        if _parallel.is_rank_zero():
+        if parallel.is_rank_zero():
             self.put_mat(self.adjoint_proj_coeffs, dest)
-        _parallel.barrier()
+        parallel.barrier()
 
 
     def compute_SVD(self, atol=1e-13, rtol=None):
@@ -244,7 +243,7 @@ class BPODHandles(object):
               range(10), mode_handles, direct_vec_handles=direct_vec_handles)
         """
         self.L_sing_vecs, self.sing_vals, self.R_sing_vecs =\
-            _parallel.call_and_bcast(
+            parallel.call_and_bcast(
             util.svd, self.Hankel_mat, atol=atol, rtol=rtol)
 
 

--- a/modred/examples/main_CGL.py
+++ b/modred/examples/main_CGL.py
@@ -9,7 +9,7 @@ import numpy as np
 import scipy.linalg as spla
 
 import modred as mr
-from . import hermite as hr
+import hermite as hr
 
 
 plots = False

--- a/modred/examples/rom_ex2.py
+++ b/modred/examples/rom_ex2.py
@@ -3,6 +3,7 @@ import os
 
 import numpy as np
 
+from modred import parallel
 import modred as mr
 
 
@@ -32,7 +33,6 @@ B_on_bases = [
     for i in range(num_inputs)]
 C_on_basis_vecs = [
     np.sin(np.linspace(0, 0.1 * i, num_outputs)) for i in range(num_modes)]
-parallel = mr.parallel_default_instance
 if parallel.is_rank_zero():
     for handle in (
         basis_vecs + adjoint_basis_vecs + A_on_basis_vecs + B_on_bases):

--- a/modred/examples/runall.py
+++ b/modred/examples/runall.py
@@ -4,10 +4,9 @@ from future.builtins import range
 
 import os
 
+from modred import parallel
 import modred as mr     # modred must be installed.
 
-
-parallel = mr.parallel_default_instance
 
 for i in range(1, 7):
     if not parallel.is_distributed():

--- a/modred/examples/tutorial_ex4.py
+++ b/modred/examples/tutorial_ex4.py
@@ -3,6 +3,7 @@ import os
 
 import numpy as np
 
+from modred import parallel
 import modred as mr
 
 
@@ -21,9 +22,8 @@ Y, X = np.meshgrid(y_grid, x_grid)
 
 snapshots = [
     mr.VecHandlePickle('%s/vec%d.pkl' % (out_dir, i)) for i in range(num_vecs)]
-parallel = mr.parallel_default_instance
 if parallel.is_rank_zero():
-    for i,snap in enumerate(snapshots):
+    for i, snap in enumerate(snapshots):
         snap.put(np.sin(X * i) + np.cos(Y * i))
 parallel.barrier()
 

--- a/modred/examples/tutorial_ex5.py
+++ b/modred/examples/tutorial_ex5.py
@@ -4,6 +4,7 @@ import os
 
 import numpy as np
 
+from modred import parallel
 import modred as mr
 
 
@@ -24,7 +25,6 @@ snapshots = [
 
 # Save arbitrary data, normally unnecessary
 num_elements = 2000
-parallel = mr.parallel_default_instance
 if parallel.is_rank_zero():
     for snap in snapshots + [base_vec_handle]:
         snap.put(np.random.random(num_elements))

--- a/modred/examples/tutorial_ex6.py
+++ b/modred/examples/tutorial_ex6.py
@@ -5,6 +5,7 @@ import os
 
 import numpy as np
 
+from modred import parallel
 import modred as mr
 from customvector import CustomVector, CustomVecHandle, inner_product
 
@@ -29,7 +30,6 @@ nz = 20
 x = np.linspace(0, 1, nx)
 y = np.logspace(1, 2, ny)
 z = np.linspace(0, 1, nz) ** 2
-parallel = mr.parallel_default_instance
 if parallel.is_rank_zero():
     for snap in direct_snapshots + adjoint_snapshots:
         snap.put(CustomVector([x, y, z], np.random.random((nx, ny, nz))))

--- a/modred/parallel.py
+++ b/modred/parallel.py
@@ -9,243 +9,221 @@ import socket
 import numpy as np
 
 
-class ParallelError(Exception):
-    """Parallel related errors"""
-    pass
+# Check to see if MPI is available by importing MPI-related modules
+try:
+    from mpi4py import MPI
+    from .reductions import Intracomm
+    _MPI_avail = True
+except ImportError:
+    _MPI_avail = False
+
+# Determine host name
+_hostname = socket.gethostname()
+_node_ID = hash(_hostname)
+
+# If MPI is available, gather MPI data
+if _MPI_avail:
+
+    # Determine number of nodes
+    comm = MPI.COMM_WORLD
+    _num_nodes = len(set(comm.allgather(_node_ID)))
+
+    # Must use custom_comm for reduce commands! This is
+    # more scalable, see reductions.py for more details
+    custom_comm = Intracomm(comm)
+
+    # To adjust number of procs, use submission script/mpiexec
+    _num_MPI_workers = comm.Get_size()
+    _rank = comm.Get_rank()
+    if _num_MPI_workers > 1:
+        _is_distributed = True
+    else:
+        _is_distributed = False
+else:
+    _num_nodes = 1
+    _num_MPI_workers = 1
+    _rank = 0
+    _is_distributed = False
+    comm = None
+    custom_comm = None
 
 
-class Parallel(object):
-    """Wrappers for parallel methods from mpi4py.
+def get_hostname():
+    """Returns hostname for this node."""
+    return _hostname
 
-    Allows user avoid errors when running in serial or without mpi4py
-    installed.  It is best to use the given instance,
-    parallel.parallel_default_instance.
+
+def get_node_ID():
+    """Returns unique ID number for this node."""
+    return _node_ID
+
+
+def get_num_nodes():
+    """Returns number of nodes."""
+    return _num_nodes
+
+
+def get_num_MPI_workers():
+    """Returns number of MPI workers (currently same as number of
+    processors)."""
+    return _num_MPI_workers
+
+
+def get_rank():
+    """Returns rank of this processor/MPI worker."""
+    return _rank
+
+
+def get_num_procs():
+    """Returns number of processors (currently same as number of MPI
+    workers)."""
+    return get_num_MPI_workers()
+
+
+def is_distributed():
+    """Returns True if there is more than one processor/MPI worker and mpi4py
+    was imported properly."""
+    return _is_distributed
+
+
+def is_rank_zero():
+    """Returns True if rank is zero, False if not."""
+    return _rank == 0
+
+
+def barrier():
+    """Wrapper for Barrier(); forces all processors/MPI workers to
+    synchronize."""
+    if _is_distributed:
+        comm.Barrier()
+
+
+def print_from_rank_zero(msgs):
+    """Prints ``msgs`` from rank zero processor/MPI worker only."""
+    if is_rank_zero():
+        print(msg)
+
+
+def call_from_rank_zero(func, *args, **kwargs):
+    """Calls function from rank zero processor/MPI worker, does not call
+    ``barrier()``.
+
+    Args:
+        ``func``: Function to call.
+
+        ``*args``: Required arguments for ``func``.
+
+        ``**kwargs``: Keyword args for ``func``.
+
+    Usage::
+
+      parallel.call_from_rank_zero(lambda x: x+1, 1)
+
     """
-    # TODO: Could be extended for shared memory.
-    def __init__(self):
-        """Constructor, tries to import mpi4py and reductions."""
-        try:
-            from mpi4py import MPI
-            self.comm = MPI.COMM_WORLD
-
-            self._node_ID = self.find_node_ID()
-            node_IDs = self.comm.allgather(self._node_ID)
-            node_IDs_no_duplicates = []
-            for ID in node_IDs:
-                if not (ID in node_IDs_no_duplicates):
-                    node_IDs_no_duplicates.append(ID)
-
-            self._num_nodes = len(node_IDs_no_duplicates)
-
-            # Must use custom_comm for reduce commands! This is
-            # more scalable, see reductions.py for more details
-            from .reductions import Intracomm
-            self.custom_comm = Intracomm(self.comm)
-
-            # To adjust number of procs, use submission script/mpiexec
-            self._num_MPI_workers = self.comm.Get_size()
-            self._rank = self.comm.Get_rank()
-            if self._num_MPI_workers > 1:
-                self.distributed = True
-            else:
-                self.distributed = False
-        except ImportError:
-            self._num_nodes = 1
-            self._num_MPI_workers = 1
-            self._rank = 0
-            self.comm = None
-            self.distributed = False
+    if is_rank_zero():
+        out = func(*args, **kwargs)
+    else:
+        out = None
+    return out
 
 
-    @staticmethod
-    def find_node_ID():
-        """Returns unique ID number for this node."""
-        hostname = socket.gethostname()
-        return hash(hostname)
+def call_and_bcast(func, *args, **kwargs):
+    """Calls function on rank zero processor/MPI worker and broadcasts
+    outputs to all others.
+
+    Args:
+        ``func``: A callable that takes ``*args`` and ``**kwargs``
+
+        ``*args``: Required arguments for ``func``.
+
+        ``**kwargs``: Keyword args for ``func``.
+
+    Usage::
+
+      # Adds one to the rank, but only evaluated on rank 0, so
+      # ``outputs==1`` on all processors/MPI workers.
+      outputs = parallel.call_and_bcast(lambda x: x+1, parallel.get_rank())
+
+    """
+    if is_rank_zero():
+        outputs = func(*args, **kwargs)
+    else:
+        outputs = None
+    if is_distributed:
+        outputs = comm.bcast(outputs, root=0)
+    return outputs
 
 
-    def get_num_nodes(self):
-        """Returns number of nodes."""
-        return self._num_nodes
+def find_assignments(tasks, task_weights=None):
+    """Evenly distributes tasks among all processors/MPI workers using task
+    weights.
 
+    Args:
+        ``tasks``: List of tasks.  A "task" can be any object that
+        corresponds to a set of operations that needs to be completed. For
+        example ``tasks`` could be a list of indices, telling each
+        processor/MPI worker which indices of an array to operate on.
 
-    def print_from_rank_zero(self, msgs):
-        """Prints ``msgs`` from rank zero processor/MPI worker only."""
-        if self.is_rank_zero():
-            print(msg)
+    Kwargs:
+        ``task_weights``: List of weights for each task.  These are used to
+        equally distribute the workload among processors/MPI workers, in
+        case some tasks are more expensive than others.
 
+    Returns:
+        ``task_assignments``: 2D list of tasks, with indices corresponding
+        to [rank][task_index].  Each processor/MPI worker is responsible
+        for ``task_assignments[rank]``
+    """
+    task_assignments = []
 
-    def barrier(self):
-        """Wrapper for Barrier(); forces all processors/MPI workers to
-        synchronize."""
-        if self.distributed:
-            self.comm.Barrier()
+    # If no weights are given, assume each task has uniform weight
+    if task_weights is None:
+        task_weights = np.ones(len(tasks))
+    else:
+        task_weights = np.array(task_weights)
 
+    first_unassigned_index = 0
 
-    def is_rank_zero(self):
-        """Returns True if rank is zero, False if not."""
-        return self._rank == 0
+    for worker_num in range(_num_MPI_workers):
+        # amount of work to do, float (scaled by weights)
+        work_remaining = sum(task_weights[first_unassigned_index:])
 
+        # Number of MPI workers whose jobs have not yet been assigned
+        num_remaining_workers = _num_MPI_workers - worker_num
 
-    def call_from_rank_zero(self, func, *args, **kwargs):
-        """Calls function from rank zero processor/MPI worker, does not call
-        ``barrier()``.
+        # Distribute work load evenly across workers
+        work_per_worker = (1. * work_remaining) / num_remaining_workers
 
-        Args:
-            ``func``: Function to call.
-
-            ``*args``: Required arguments for ``func``.
-
-            ``**kwargs``: Keyword args for ``func``.
-
-        Usage::
-
-          parallel.call_from_rank_zero(lambda x: x+1, 1)
-
-        """
-        if self.is_rank_zero():
-            out = func(*args, **kwargs)
+        # If task list is not empty, compute assignments
+        if task_weights[first_unassigned_index:].size != 0:
+            # Index of tasks element which has sum(tasks[:ind])
+            # closest to work_per_worker
+            new_max_task_index = np.abs(np.cumsum(
+                task_weights[first_unassigned_index:]) -\
+                work_per_worker).argmin() + first_unassigned_index
+            # Append all tasks up to and including new_max_task_index
+            task_assignments.append(tasks[first_unassigned_index:\
+                new_max_task_index+1])
+            first_unassigned_index = new_max_task_index+1
         else:
-            out = None
-        return out
+            task_assignments.append([])
+
+    return task_assignments
 
 
-    def is_distributed(self):
-        """Returns True if more than one processor/MPI worker and mpi4py
-        imported properly."""
-        return self.distributed
+def check_for_empty_tasks(task_assignments):
+    """Convenience function that checks for empty processor/MPI worker
+    assignments.
 
+    Args:
+        ``task_assignments``: List of task assignments.
 
-    def get_rank(self):
-        """Returns rank of this processor/MPI worker."""
-        return self._rank
-
-
-    def get_num_MPI_workers(self):
-        """Returns number of processors/MPI workers, currently same as
-        ``num_procs``."""
-        return self._num_MPI_workers
-
-
-    def get_num_procs(self):
-        """Returns number of processors/MPI workers."""
-        return self.get_num_MPI_workers()
-
-
-    def find_assignments(self, tasks, task_weights=None):
-        """Evenly distributes tasks among all processors/MPI workers using task
-        weights.
-
-        Args:
-            ``tasks``: List of tasks.  A "task" can be any object that
-            corresponds to a set of operations that needs to be completed. For
-            example ``tasks`` could be a list of indices, telling each
-            processor/MPI worker which indices of an array to operate on.
-
-        Kwargs:
-            ``task_weights``: List of weights for each task.  These are used to
-            equally distribute the workload among processors/MPI workers, in
-            case some tasks are more expensive than others.
-
-        Returns:
-            ``task_assignments``: 2D list of tasks, with indices corresponding
-            to [rank][task_index].  Each processor/MPI worker is responsible
-            for ``task_assignments[rank]``
-        """
-        task_assignments = []
-
-        # If no weights are given, assume each task has uniform weight
-        if task_weights is None:
-            task_weights = np.ones(len(tasks))
-        else:
-            task_weights = np.array(task_weights)
-
-        first_unassigned_index = 0
-
-        for worker_num in range(self._num_MPI_workers):
-            # amount of work to do, float (scaled by weights)
-            work_remaining = sum(task_weights[first_unassigned_index:])
-
-            # Number of MPI workers whose jobs have not yet been assigned
-            num_remaining_workers = self._num_MPI_workers - worker_num
-
-            # Distribute work load evenly across workers
-            work_per_worker = (1. * work_remaining) / num_remaining_workers
-
-            # If task list is not empty, compute assignments
-            if task_weights[first_unassigned_index:].size != 0:
-                # Index of tasks element which has sum(tasks[:ind])
-                # closest to work_per_worker
-                new_max_task_index = np.abs(np.cumsum(
-                    task_weights[first_unassigned_index:]) -\
-                    work_per_worker).argmin() + first_unassigned_index
-                # Append all tasks up to and including new_max_task_index
-                task_assignments.append(tasks[first_unassigned_index:\
-                    new_max_task_index+1])
-                first_unassigned_index = new_max_task_index+1
-            else:
-                task_assignments.append([])
-
-        return task_assignments
-
-
-    def check_for_empty_tasks(self, task_assignments):
-        """Convenience function that checks for empty processor/MPI worker
-        assignments.
-
-        Args:
-            ``task_assignments``: List of task assignments.
-
-        Returns:
-            ``empty_tasks``: ``True`` if any processor/MPI worker has no tasks,
-            otherwise ``False``.
-        """
-        empty_tasks = False
-        for assignment in task_assignments:
-            if len(assignment) == 0 and not empty_tasks:
-                empty_tasks = True
-        return empty_tasks
-
-
-    def call_and_bcast(self, func, *args, **kwargs):
-        """Calls function on rank zero processor/MPI worker and broadcasts
-        outputs to all others.
-
-        Args:
-            ``func``: A callable that takes ``*args`` and ``**kwargs``
-
-            ``*args``: Required arguments for ``func``.
-
-            ``**kwargs``: Keyword args for ``func``.
-
-        Usage::
-
-          # Adds one to the rank, but only evaluated on rank 0, so
-          # ``outputs==1`` on all processors/MPI workers.
-          outputs = parallel.call_and_bcast(lambda x: x+1, parallel.get_rank())
-
-        """
-        if self.is_rank_zero():
-            outputs = func(*args, **kwargs)
-        else:
-            outputs = None
-        if self.is_distributed():
-            outputs = self.comm.bcast(outputs, root=0)
-        return outputs
-
-
-    def __eq__(self, other):
-        equal = (self._num_MPI_workers == other.get_num_MPI_workers() and \
-        self._rank == other.get_rank() and \
-        self.distributed == other.is_distributed())
-        #print self._numProcs == other.getNumProcs() ,\
-        #self._rank == other.getRank() ,self.parallel == other.isParallel()
-        return equal
-
-
-    def __ne__(self, other):
-        return not (self.__eq__(other))
-
-
-# Default instance to be used everywhere, "singleton"
-parallel_default_instance = Parallel()
+    Returns:
+        ``empty_tasks``: ``True`` if any processor/MPI worker has no tasks,
+        otherwise ``False``.
+    """
+    empty_tasks = False
+    for assignment in task_assignments:
+        if len(assignment) == 0 and not empty_tasks:
+            empty_tasks = True
+    return empty_tasks

--- a/modred/tests/testera.py
+++ b/modred/tests/testera.py
@@ -9,8 +9,7 @@ from shutil import rmtree
 
 import numpy as np
 
-import modred.parallel as parallel_mod
-_parallel = parallel_mod.parallel_default_instance
+import modred.parallel as parallel
 from modred import era
 from modred import util
 
@@ -35,7 +34,7 @@ def make_time_steps(num_steps, interval):
     return time_steps
 
 
-@unittest.skipIf(_parallel.is_distributed(), 'Only test ERA in serial')
+@unittest.skipIf(parallel.is_distributed(), 'Only test ERA in serial')
 class testERA(unittest.TestCase):
     def setUp(self):
         if not os.access('.', os.W_OK):

--- a/modred/tests/testexamples.py
+++ b/modred/tests/testexamples.py
@@ -10,8 +10,7 @@ import os, sys
 from os.path import join
 from shutil import rmtree
 
-import modred.parallel as parallel_mod
-_parallel = parallel_mod.parallel_default_instance
+import modred.parallel as parallel
 
 
 # Directory we start from, absolute path.
@@ -50,23 +49,23 @@ def printing(on):
 
 class TestExamples(unittest.TestCase):
     def setUp(self):
-        _parallel.barrier()
+        parallel.barrier()
         self.test_dir = join(running_dir, 'DELETE_ME_test_tutorial_examples')
         if not os.access('.', os.W_OK):
             raise RuntimeError('Cannot write to current directory')
-        if not os.path.isdir(self.test_dir) and _parallel.is_rank_zero():
+        if not os.path.isdir(self.test_dir) and parallel.is_rank_zero():
             os.mkdir(self.test_dir)
-        _parallel.barrier()
+        parallel.barrier()
 
         os.chdir(self.test_dir)
 
 
     def tearDown(self):
         os.chdir(running_dir)
-        _parallel.barrier()
-        if _parallel.is_rank_zero():
+        parallel.barrier()
+        if parallel.is_rank_zero():
             rmtree(self.test_dir, ignore_errors=True)
-        _parallel.barrier()
+        parallel.barrier()
 
 
     @unittest.skip('Test with Makefile in examples directory instead')
@@ -75,11 +74,11 @@ class TestExamples(unittest.TestCase):
         example_script = 'tutorial_ex%d.py'
         for example_num in range(1, 7):
             # Example 3 isn't meant to work in parallel
-            if not (_parallel.is_distributed() and example_num != 3):
+            if not (parallel.is_distributed() and example_num != 3):
                 #printing(False)
-                _parallel.barrier()
+                parallel.barrier()
                 execfile(join(examples_dir, example_script%example_num))
-                _parallel.barrier()
+                parallel.barrier()
                 #printing(True)
 
 

--- a/modred/tests/testokid.py
+++ b/modred/tests/testokid.py
@@ -8,8 +8,7 @@ import unittest
 
 import numpy as np
 
-import modred.parallel as parallel_mod
-_parallel = parallel_mod.parallel_default_instance
+import modred.parallel as parallel
 from modred.okid import OKID
 from modred import util
 
@@ -31,7 +30,7 @@ def diff(arr_measured, arr_true, normalize=False):
         return err
 
 
-@unittest.skipIf(_parallel.is_distributed(), 'Only test OKID in serial')
+@unittest.skipIf(parallel.is_distributed(), 'Only test OKID in serial')
 class TestOKID(unittest.TestCase):
     def setUp(self):
         self.test_dir = join(os.path.dirname(__file__), 'files_okid')

--- a/modred/tests/testparallel.py
+++ b/modred/tests/testparallel.py
@@ -6,8 +6,7 @@ import copy
 import os
 from os.path import join
 
-import modred.parallel as parallel_mod
-parallel = parallel_mod.parallel_default_instance
+import modred.parallel as parallel
 
 
 try:
@@ -30,7 +29,6 @@ class TestParallel(unittest.TestCase):
         except ImportError:
             self.num_MPI_workers = 1
             self.rank = 0
-        self.my_parallel = parallel_mod.Parallel()
 
 
     def tearDown(self):
@@ -46,14 +44,6 @@ class TestParallel(unittest.TestCase):
         # not sure how to test this
 
 
-    def test_init(self):
-        """Test that the MPI object uses arguments correctly.
-        """
-        self.assertEqual(
-            self.my_parallel._num_MPI_workers, self.num_MPI_workers)
-        self.assertEqual(self.my_parallel._rank, self.rank)
-
-
     def test_find_assignments(self):
         """Tests that the correct processor assignments are determined
 
@@ -62,59 +52,68 @@ class TestParallel(unittest.TestCase):
         with many different numbers of procs the behavior of this function
         is mimicked by manually setting num_MPI_workers
         """
+        # Store original number of MPI workers, as this value will be globally
+        # modified for testing the parallel module, and needs to be changed
+        # back to its original value
+        num_MPI_workers_true = parallel.get_num_MPI_workers()
+
         # Assume each item in task list has equal weight
         tasks = ['1', '2', '4', '3', '6', '7', '5']
         copy_task_list = copy.deepcopy(tasks)
-        self.my_parallel._num_MPI_workers = 5
+        parallel._num_MPI_workers = 5
         correct_assignments = [['1'], ['2'], ['4', '3'], ['6'], ['7', '5']]
-        self.assertEqual(self.my_parallel.find_assignments(tasks),
-            correct_assignments)
+        self.assertEqual(
+            parallel.find_assignments(tasks), correct_assignments)
+
         # Check that the original list is not modified.
         self.assertEqual(tasks, copy_task_list)
 
         tasks = [3, 4, 1, 5]
-        self.my_parallel._num_MPI_workers = 2
+        parallel._num_MPI_workers = 2
         correct_assignments = [[3, 4], [1, 5]]
-        self.assertEqual(self.my_parallel.find_assignments(tasks),
-            correct_assignments)
+        self.assertEqual(
+            parallel.find_assignments(tasks), correct_assignments)
 
         # Allow for uneven weighting of items in task list
         tasks = ['1', '2', '4', '3', '6', '7', '5']
         task_weights = [1, 3, 2, 3, 3, 2, 1]
-        self.my_parallel._num_MPI_workers = 5
+        parallel._num_MPI_workers = 5
         correct_assignments = [['1','2'], ['4'], ['3'], ['6'], ['7', '5']]
-        self.assertEqual(self.my_parallel.find_assignments(tasks,
-            task_weights=task_weights), correct_assignments)
+        self.assertEqual(parallel.find_assignments(
+            tasks, task_weights=task_weights), correct_assignments)
 
         # At first, each proc tries to take a task weight load of 2.  This is
         # closer to 0 than it is to 5, but the first assignment should be [3],
         # not []
         tasks = [3, 4, 2, 6, 1]
         task_weights = [5, 0.25, 1.75, 0.5, 0.5]
-        self.my_parallel._num_MPI_workers = 4
+        parallel._num_MPI_workers = 4
         correct_assignments = [[3], [4], [2], [6, 1]]
-        self.assertEqual(self.my_parallel.find_assignments(tasks,
-            task_weights=task_weights), correct_assignments)
+        self.assertEqual(parallel.find_assignments(
+            tasks, task_weights=task_weights), correct_assignments)
 
         # Due to the highly uneven task weighting, the first proc will take up
         # the first 3 tasks, leaving none for the last processor
         tasks = ['a', 4, (2, 1), 4.3]
         task_weights = [.1, .1, .1, .7]
         copy_task_weights = copy.deepcopy(task_weights)
-        self.my_parallel._num_MPI_workers = 3
+        parallel._num_MPI_workers = 3
         correct_assignments = [['a', 4, (2, 1)], [4.3], []]
-        self.assertEqual(self.my_parallel.find_assignments(tasks,
-            task_weights=task_weights), correct_assignments)
+        self.assertEqual(parallel.find_assignments(
+            tasks, task_weights=task_weights), correct_assignments)
         self.assertEqual(task_weights, copy_task_weights)
+
+        # Reset number of MPI workers in parallel module, as this is
+        # essentially a global variable
+        parallel._num_MPI_workers = num_MPI_workers_true
 
 
     def test_call_and_bcast(self):
         """Call a function on rank zero and bcast outputs to all MPI workers."""
         def add_and_scale(arg1, arg2, scale=1):
             return True, scale*(arg1 + arg2)
-
-        outputs = self.my_parallel.call_and_bcast(add_and_scale,
-            self.my_parallel.get_rank()+1, 2, scale=3)
+        outputs = parallel.call_and_bcast(
+            add_and_scale, parallel.get_rank() + 1, 2, scale=3)
         self.assertEqual(outputs, (True, 9))
 
 

--- a/modred/tests/testutil.py
+++ b/modred/tests/testutil.py
@@ -8,8 +8,7 @@ from os.path import join
 
 import numpy as np
 
-import modred.parallel as parallel_mod
-_parallel = parallel_mod.parallel_default_instance
+import modred.parallel as parallel
 from modred import util
 
 
@@ -22,20 +21,20 @@ class TestUtil(unittest.TestCase):
         self.test_dir = 'DELETE_ME_test_files_util'
         if not os.access('.', os.W_OK):
             raise RuntimeError('Cannot write to current directory')
-        if _parallel.is_rank_zero():
+        if parallel.is_rank_zero():
             if not os.path.isdir(self.test_dir):
                 os.mkdir(self.test_dir)
 
 
     def tearDown(self):
-        _parallel.barrier()
-        if _parallel.is_rank_zero():
+        parallel.barrier()
+        if parallel.is_rank_zero():
             rmtree(self.test_dir, ignore_errors=True)
-        _parallel.barrier()
+        parallel.barrier()
 
 
     @unittest.skipIf(
-        _parallel.is_distributed(), 'Only save/load matrices in serial')
+        parallel.is_distributed(), 'Only save/load matrices in serial')
     def test_load_save_array_text(self):
         """Test that can read/write text matrices"""
         #tol = 1e-8
@@ -68,7 +67,7 @@ class TestUtil(unittest.TestCase):
                             np.testing.assert_allclose(mat_read, mat)#,rtol=tol)
 
 
-    @unittest.skipIf(_parallel.is_distributed(), 'Only load matrices in serial')
+    @unittest.skipIf(parallel.is_distributed(), 'Only load matrices in serial')
     def test_svd(self):
         # Set tolerance for testing eigval/eigvec property
         test_tol = 1e-10
@@ -138,7 +137,7 @@ class TestUtil(unittest.TestCase):
                                 abs(sing_vals[0]) / abs(sing_vals[-1]) > rtol)
 
 
-    @unittest.skipIf(_parallel.is_distributed(), 'Only load matrices in serial')
+    @unittest.skipIf(parallel.is_distributed(), 'Only load matrices in serial')
     def test_eigh(self):
         # Set tolerance for test of eigval/eigvec properties.  Value necessary
         # for test to pass depends on matrix size, as well as atol and rtol
@@ -232,7 +231,7 @@ class TestUtil(unittest.TestCase):
                         self.assertTrue(abs(eigvals).min() > atol)
 
 
-    @unittest.skipIf(_parallel.is_distributed(), 'Only load matrices in serial')
+    @unittest.skipIf(parallel.is_distributed(), 'Only load matrices in serial')
     def test_eig_biorthog(self):
         test_tol = 1e-10
         num_rows = 100
@@ -277,7 +276,7 @@ class TestUtil(unittest.TestCase):
             ValueError, util.eig_biorthog, mat, **{'scale_choice':'invalid'})
 
 
-    @unittest.skipIf(_parallel.is_distributed(), 'Only load data in serial')
+    @unittest.skipIf(parallel.is_distributed(), 'Only load data in serial')
     def test_load_impulse_outputs(self):
         """
         Test loading multiple signal files in [t sig1 sig2 ...] format.
@@ -309,7 +308,7 @@ class TestUtil(unittest.TestCase):
                     np.testing.assert_allclose(time_values, time_values_true)
 
 
-    @unittest.skipIf(_parallel.is_distributed(), 'Serial only.')
+    @unittest.skipIf(parallel.is_distributed(), 'Serial only.')
     def test_solve_Lyapunov(self):
         """Test solution of Lyapunov w/known solution from Matlab's dlyap"""
         A = np.array([[0.725404224946106, 0.714742903826096],
@@ -329,7 +328,7 @@ class TestUtil(unittest.TestCase):
         np.testing.assert_allclose(X_computed_mats, X_true)
 
 
-    @unittest.skipIf(_parallel.is_distributed(), 'Serial only.')
+    @unittest.skipIf(parallel.is_distributed(), 'Serial only.')
     def test_balanced_truncation(self):
         """Test balanced system is close to original."""
         for num_inputs in [1, 3]:
@@ -343,7 +342,7 @@ class TestUtil(unittest.TestCase):
                     np.testing.assert_allclose(yr, y, rtol=1e-5)
 
 
-    @unittest.skipIf(_parallel.is_distributed(), 'Serial only.')
+    @unittest.skipIf(parallel.is_distributed(), 'Serial only.')
     def test_drss(self):
         """Test drss gives correct mat dimensions and stable dynamics."""
         for num_states in [1, 5, 14]:
@@ -356,7 +355,7 @@ class TestUtil(unittest.TestCase):
                     self.assertTrue(np.amax(np.abs(np.linalg.eig(A)[0])) < 1)
 
 
-    @unittest.skipIf(_parallel.is_distributed(), 'Serial only.')
+    @unittest.skipIf(parallel.is_distributed(), 'Serial only.')
     def test_lsim(self):
         """Test that lsim has right shapes, does not test result"""
         for num_states in [1, 4, 9]:
@@ -373,7 +372,7 @@ class TestUtil(unittest.TestCase):
                     self.assertEqual(outputs.shape, (nt, num_outputs))
 
 
-    @unittest.skipIf(_parallel.is_distributed(), 'Serial only.')
+    @unittest.skipIf(parallel.is_distributed(), 'Serial only.')
     def test_impulse(self):
         """Test impulse response of discrete system"""
         for num_states in [1, 10]:

--- a/modred/tests/testvectors.py
+++ b/modred/tests/testvectors.py
@@ -8,8 +8,7 @@ from shutil import rmtree
 
 import numpy as np
 
-import modred.parallel as parallel_mod
-parallel = parallel_mod.parallel_default_instance
+import modred.parallel as parallel
 import modred.vectors as V
 
 


### PR DESCRIPTION
Suggested usage was to make use of the default instance of Parallel anyway, as
if it were a singleton.  This change enforces that usage.  There was really no
need to have the ability to create multiple instances of Parallel objects
anyway.  Now, users should be careful, as variables defined within parallel are
essentially global, so they should only be modified with extreme care.