### PR TITLE
fixes 'Version' obj. not iterable issue in line 20

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open(os.path.join(here, 'README.rst')) as f:
 with open(os.path.join(here, 'modred/_version.py')) as f:
     exec(f.read())
 # Get the development status from the version string
-parsed_version = parse_version(__version__)
+parsed_version = str(parse_version(__version__))
 if any(w in ['*a', '*alpha'] for w in parsed_version):
     devstatus = 'Development Status :: 3 - Alpha'
 elif any(w in ['*b', '*beta'] for w in parsed_version):


### PR DESCRIPTION
On macOS Mojave, using ports python version 2.7.15 there was an installation error:
```
Traceback (most recent call last):
  File "setup.py", line 20, in <module>
    if any(w in ['*a', '*alpha'] for w in parsed_version):
TypeError: 'Version' object is not iterable
```
This simple conversion fixed that. Perhaps only a suggestion, as there may be more apt ways of addressing that:) Thanks.